### PR TITLE
Wip/ppc abi

### DIFF
--- a/renovate-ppc/renovate-ppc.cabal
+++ b/renovate-ppc/renovate-ppc.cabal
@@ -18,6 +18,7 @@ cabal-version:       >=1.10
 library
   exposed-modules:     Renovate.Arch.PPC
   other-modules:       Renovate.Arch.PPC.ISA
+                       Renovate.Arch.PPC.ABI
   -- other-extensions:    
   build-depends:       base >=4.10 && <5,
                        bytestring,

--- a/renovate-ppc/src/Renovate/Arch/PPC.hs
+++ b/renovate-ppc/src/Renovate/Arch/PPC.hs
@@ -23,9 +23,6 @@ module Renovate.Arch.PPC (
   MP.parseTOC,
   MP.lookupTOC,
   MP.entryPoints,
-  -- * Instruction Helpers
-  toInst,
-  fromInst,
   -- * Exceptions
   InstructionDisassemblyFailure(..)
   ) where
@@ -106,6 +103,7 @@ instance R.ArchInfo MP.PPC32 where
                                     k (MPS.ppc32MacawEvalFn sfns)
                                 , R.withArchConstraints = \x -> x
                                 })
+
 
 {- Note [Layout Addresses]
 

--- a/renovate-ppc/src/Renovate/Arch/PPC.hs
+++ b/renovate-ppc/src/Renovate/Arch/PPC.hs
@@ -13,6 +13,8 @@ module Renovate.Arch.PPC (
   MP.PPC32,
   -- * Functions
   isa,
+  abi32,
+  abi64,
   -- * Assembly and Disassembly
   assemble,
   disassemble,
@@ -39,6 +41,7 @@ import qualified Data.Macaw.PPC.Symbolic as MPS
 
 import qualified Renovate as R
 import           Renovate.Arch.PPC.ISA
+import           Renovate.Arch.PPC.ABI
 
 -- | A renovate configuration for 32 bit PowerPC
 config32 :: (MM.MemWidth w, w ~ 32, MC.ArchAddrWidth MP.PPC32 ~ w, MBL.BinaryLoader MP.PPC32 binFmt, MBL.ArchBinaryData MP.PPC32 binFmt ~ MP.TOC MP.PPC32)

--- a/renovate-ppc/src/Renovate/Arch/PPC/ABI.hs
+++ b/renovate-ppc/src/Renovate/Arch/PPC/ABI.hs
@@ -1,0 +1,97 @@
+{-# LANGUAGE ScopedTypeVariables, TypeApplications, DataKinds, GADTs #-}
+
+-- | An 'ABI' implementation for the PPC ABI
+
+module Renovate.Arch.PPC.ABI ( abi64
+                             , abi32
+                             , instrOpcode
+                             ) where
+
+import qualified Data.Macaw.PPC as PPC
+import qualified Dismantle.PPC  as D
+import qualified Renovate       as R
+import           Renovate.Arch.PPC.ISA
+
+import qualified Data.Parameterized.Some as Some
+
+-- TODO: some of this could be moved into an Internals.hs
+
+-- | Note that allocateMemory, computeStackPointerOffset, saveReturnaddress, and
+-- checkShadowStack, are currently used only for the Shadow stack embrittle
+-- transforamtion, which we are not applying on PPC right now. As a result, we
+-- leave these undefined for the time being.
+abi64 :: R.ABI PPC.PPC64
+abi64 = R.ABI { R.isReturn            = ppcIsReturn . R.toGenericInstruction @PPC.PPC64 
+            , R.callerSaveRegisters = ppcCallerSaveRegisters64
+            , R.clearRegister       = fmap (const NoAddress) 
+                                    . R.fromGenericInstruction @PPC.PPC64 
+                                    . ppcClearRegister
+            , R.pointerSize         = 8
+            -- | these are all for shadow stack; leave undefined
+            , R.allocateMemory            = undefined
+            , R.computeStackPointerOffset = undefined
+            , R.saveReturnAddress         = undefined
+            , R.checkShadowStack          = undefined
+            }
+
+-- | Note that allocateMemory, computeStackPointerOffset, saveReturnaddress, and
+-- checkShadowStack, are currently used only for the Shadow stack embrittle
+-- transforamtion, which we are not applying on PPC right now. As a result, we
+-- leave these undefined for the time being.
+abi32 :: R.ABI PPC.PPC32
+abi32 = R.ABI { R.isReturn            = ppcIsReturn . R.toGenericInstruction @PPC.PPC32
+            , R.callerSaveRegisters = ppcCallerSaveRegisters32
+            , R.clearRegister       = fmap (const NoAddress) 
+                                    . R.fromGenericInstruction @PPC.PPC32
+                                    . ppcClearRegister
+            , R.pointerSize         = 4
+            -- | these are all for shadow stack; leave undefined
+            , R.allocateMemory            = undefined
+            , R.computeStackPointerOffset = undefined
+            , R.saveReturnAddress         = undefined
+            , R.checkShadowStack          = undefined
+            }
+
+
+-- | Retrieve the 'String' opcode from an instruction (for diagnostic purposes)
+instrOpcode :: D.Instruction -> String
+instrOpcode (D.Instruction opcode operands) = show opcode
+
+-- is return if it matches BLR (branch to link register) or BLRL 
+ppcIsReturn :: D.Instruction -> Bool
+ppcIsReturn instr = instrOpcode instr == "BLR" || instrOpcode instr == "BLRL"
+
+
+-- | Caller save registers for PPC64 (called "volitile" in the
+-- [documentation]<https://gitlab-int.galois.com/brittle/sfe/uploads/5bfc68a341709773ff8cb24552ece62b/PPC-elf64abi-1.7.pdf>)
+--
+-- For now we are only accounting for general-purpose registers @r4@-@r10@.
+ppcCallerSaveRegisters64 :: [R.RegisterType PPC.PPC64]
+ppcCallerSaveRegisters64 = map (Some.Some . D.Gprc . D.GPR)  [4..10]
+  where
+--    generalRegisters   = [0] ++ [3..12]
+--    floatingRegisters  = [0..13]
+--    conditionRegisters = [0,1,5,6,7,8]
+--    vectorRegisters    = [0..19]
+
+-- | Caller save registers for PPC32 (called "volitile" in the
+-- [documentation]<https://gitlab-int.galois.com/brittle/sfe/uploads/793d984241f4c4546e0f81cdfe1643f4/elfspec_ppc.pdf>)
+--
+-- For now we are only accounting for general-purpose registers @r5@-@r12@.
+ppcCallerSaveRegisters32 :: [R.RegisterType PPC.PPC32]
+ppcCallerSaveRegisters32 =  map (Some.Some . D.Gprc . D.GPR)  [5..12]
+
+
+
+-- | Create an instruction to clear a register (i.e., set it to zero or some
+-- other distinguished neutral value).
+--
+-- XOR r r r
+ppcClearRegister :: R.RegisterType PPC.PPC64 -> D.Instruction
+ppcClearRegister r = D.Instruction D.XOR (coerceOperand r D.:< coerceOperand r D.:< coerceOperand r D.:< D.Nil)
+
+
+
+coerceOperand :: Some.Some D.Operand -> D.Operand "Gprc"
+coerceOperand (Some.Some (D.Gprc x)) = D.Gprc x
+coerceOperand op                     = error $ "Tried to clear an unsupported register in PPC: " ++ show op

--- a/renovate-ppc/src/Renovate/Arch/PPC/ABI.hs
+++ b/renovate-ppc/src/Renovate/Arch/PPC/ABI.hs
@@ -4,7 +4,6 @@
 
 module Renovate.Arch.PPC.ABI ( abi64
                              , abi32
-                             , instrOpcode
                              ) where
 
 import qualified Data.Macaw.PPC as PPC
@@ -53,13 +52,12 @@ abi32 = R.ABI { R.isReturn            = ppcIsReturn . R.toGenericInstruction @PP
             }
 
 
--- | Retrieve the 'String' opcode from an instruction (for diagnostic purposes)
-instrOpcode :: D.Instruction -> String
-instrOpcode (D.Instruction opcode operands) = show opcode
 
 -- is return if it matches BLR (branch to link register) or BLRL 
 ppcIsReturn :: D.Instruction -> Bool
-ppcIsReturn instr = instrOpcode instr == "BLR" || instrOpcode instr == "BLRL"
+ppcIsReturn (D.Instruction D.BLR _)  = True
+ppcIsReturn (D.Instruction D.BLRL _) = True
+ppcIsReturn _                        = False
 
 
 -- | Caller save registers for PPC64 (called "volitile" in the

--- a/renovate-ppc/src/Renovate/Arch/PPC/ISA.hs
+++ b/renovate-ppc/src/Renovate/Arch/PPC/ISA.hs
@@ -4,15 +4,13 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE UndecidableInstances, TypeSynonymInstances #-}
 module Renovate.Arch.PPC.ISA (
   isa,
   assemble,
   disassemble,
   Instruction,
   TargetAddress(..),
-  toInst,
-  fromInst,
   -- * Exceptions
   InstructionDisassemblyFailure(..)
   ) where
@@ -350,8 +348,19 @@ newJumpOffset nBits srcAddr targetAddr
   where
     rawOff = targetAddr `R.addressDiff` srcAddr
 
+-- | These are orphan instances; is there a better place to put them?
+instance R.ToGenericInstruction MP.PPC32 where
+  toGenericInstruction   = toInst
+  fromGenericInstruction = fromInst
+
+instance R.ToGenericInstruction MP.PPC64 where
+  toGenericInstruction   = toInst
+  fromGenericInstruction = fromInst
+
+
 -- | Convert the 'Instruction' wrapper to the base instruction type, dropping
--- annotations.
+-- annotations. This operation is depricated in favor of
+-- 'R.toGenericInstruction'.
 --
 -- Note that the coercion of the opcode is safe, because the second type
 -- parameter is phantom.
@@ -362,7 +371,8 @@ toInst i =
       D.Instruction (coerce opc) (FC.fmapFC unannotateOpcode annotatedOps)
 
 -- | Convert the base instruction type to the wrapped 'Instruction' with a unit
--- annotation.
+-- annotation. This operation is depricated in favor of
+-- 'R.fromGenericInstruction'.
 fromInst :: D.Instruction -> Instruction ()
 fromInst i =
   case i of

--- a/renovate/renovate.cabal
+++ b/renovate/renovate.cabal
@@ -60,6 +60,7 @@ library
                        macaw-symbolic,
                        crucible,
                        elf-edit >= 0.28,
+                       semmc,
                        what4
 
   hs-source-dirs:      src

--- a/renovate/src/Renovate.hs
+++ b/renovate/src/Renovate.hs
@@ -49,6 +49,7 @@ module Renovate
   B.Instruction,
   B.InstructionAnnotation,
   B.RegisterType,
+  B.ToGenericInstruction(..),
   -- * Addresses
   A.SymbolicAddress,
   A.ConcreteAddress,

--- a/renovate/src/Renovate/BasicBlock.hs
+++ b/renovate/src/Renovate/BasicBlock.hs
@@ -10,6 +10,7 @@ module Renovate.BasicBlock (
   SymbolicBlock,
   Instruction,
   InstructionAnnotation,
+  ToGenericInstruction(..),
   RegisterType,
   AddressAssignedBlock(..),
   SymbolicInfo(..),

--- a/renovate/src/Renovate/BasicBlock/Types.hs
+++ b/renovate/src/Renovate/BasicBlock/Types.hs
@@ -69,7 +69,7 @@ type family RegisterType arch :: *
 -- instructions, but is true for PowerPC.
 class ToGenericInstruction arch 
   where
-    toGenericInstruction   :: Instruction arch () -> SA.Instruction arch
+    toGenericInstruction   :: Instruction arch a  -> SA.Instruction arch
     fromGenericInstruction :: SA.Instruction arch -> Instruction arch  ()
 
 -- | Constraints common to all instructions.

--- a/renovate/src/Renovate/BasicBlock/Types.hs
+++ b/renovate/src/Renovate/BasicBlock/Types.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE AllowAmbiguousTypes #-}
 module Renovate.BasicBlock.Types (
   BasicBlock(..),
   Instruction,
@@ -18,6 +19,7 @@ module Renovate.BasicBlock.Types (
   hasNoSymbolicTarget,
   symbolicTarget,
   projectInstruction,
+  ToGenericInstruction(..),
   -- * Constraints
   InstructionConstraints
   ) where
@@ -27,6 +29,8 @@ import qualified Data.Text.Prettyprint.Doc as PD
 import           Data.Typeable ( Typeable )
 
 import qualified Data.Macaw.CFG as MC
+
+import qualified SemMC.Architecture as SA
 
 import           Renovate.Address
 
@@ -58,6 +62,15 @@ type family InstructionAnnotation arch :: *
 
 -- | The type of register values for the architecture
 type family RegisterType arch :: *
+
+-- | Concrete renovate instructions of the type @'Instruction' arch ()@ are in
+-- several cases equivalent to semmc instructions of type
+-- @'SemMC.Architecture.Instruction' arch@. This property is not true for X86
+-- instructions, but is true for PowerPC.
+class ToGenericInstruction arch 
+  where
+    toGenericInstruction   :: Instruction arch () -> SA.Instruction arch
+    fromGenericInstruction :: SA.Instruction arch -> Instruction arch  ()
 
 -- | Constraints common to all instructions.
 --

--- a/stack-8.2.2.yaml
+++ b/stack-8.2.2.yaml
@@ -29,14 +29,10 @@ packages:
 - deps/semmc/semmc
 - deps/semmc/semmc-ppc
 extra-deps:
-- IntervalMap-0.5.3.1
-- Only-0.1
-- QuickCheck-2.10.1
-- StateVar-1.1.0.4
 - adjunctions-4.3
 - ansi-terminal-0.7.1.1
 - ansi-wl-pprint-0.6.8.1
-- async-2.1.1.1
+- async-2.2.1
 - attoparsec-0.13.2.0
 - auto-update-0.1.4
 - base-compat-0.9.3
@@ -58,6 +54,7 @@ extra-deps:
 - conduit-extra-1.2.0
 - constraints-0.9.1
 - contravariant-1.4
+- data-binary-ieee754-0.4.4
 - direct-sqlite-2.3.21
 - distributive-0.5.3
 - easy-file-0.2.1
@@ -69,10 +66,12 @@ extra-deps:
 - free-4.12.4
 - generic-deriving-1.11.2
 - generic-lens-0.5.1.0
+- gitrev-1.3.1
 - hashable-1.2.6.1
 - hashtables-1.2.2.1
 - heaps-0.3.5
 - integer-logarithms-1.0.2
+- IntervalMap-0.5.3.1
 - io-streams-1.5.0.1
 - kan-extensions-5.0.2
 - lens-4.15.4
@@ -89,7 +88,9 @@ extra-deps:
 - network-2.6.3.2
 - old-locale-1.0.0.7
 - old-time-1.1.0.3
+- Only-0.1
 - optparse-applicative-0.14.0.0
+- panic-0.4.0.1
 - parallel-3.2.1.1
 - parsec-3.1.11
 - parser-combinators-0.2.0
@@ -98,6 +99,7 @@ extra-deps:
 - prettyprinter-1.1.1
 - primitive-0.6.2.0
 - profunctors-5.2.1
+- QuickCheck-2.10.1
 - random-1.1
 - reflection-2.1.2
 - regex-1.0.0.0
@@ -110,6 +112,7 @@ extra-deps:
 - semigroups-0.18.3
 - split-0.2.3.2
 - sqlite-simple-0.4.14.0
+- StateVar-1.1.0.4
 - stm-2.4.4.1
 - stm-chans-3.0.0.4
 - streaming-commons-0.1.18


### PR DESCRIPTION
This branch extends the renovate-ppc module with (incomplete) support for a PowerPC ABI. The support is incomplete because not all the data in the ABI is necessary for every analysis. The only change in interface is to generalize `Renovate.Arch.PPC.toInst` (and similarly `fromInst`) to a type class `Renovate.ToGenericInstruction` that is parameterized by the architecture.