### PR TITLE
renovate-x86: build requires flexdis >=0.1.4

### DIFF
--- a/renovate-x86/renovate-x86.cabal
+++ b/renovate-x86/renovate-x86.cabal
@@ -23,7 +23,7 @@ library
   -- other-extensions:    
   build-depends:       base >=4.10 && <5,
                        bytestring,
-                       flexdis86,
+                       flexdis86 >=0.1.4,
                        macaw-x86,
                        macaw-x86-symbolic,
                        macaw-base,


### PR DESCRIPTION
renovate-x86 uses a constructor introduced in https://github.com/GaloisInc/flexdis86/commit/f1727bf2c9462711e52dd75cb3cac10fff6a2812

It's nice to have this lower bound be explicit. I encountered this when I built
a project that depended on renovate-x86 but hadn't done a _recursive_ git
submodule init, this would have helped me debug the problem faster.