### PR TITLE
Return RewriterEnv from ELF rewriter

### DIFF
--- a/renovate/src/Renovate.hs
+++ b/renovate/src/Renovate.hs
@@ -109,6 +109,7 @@ module Renovate
   RW.RewriteSite(..),
   E.SomeBlocks(..),
   E.RewriterInfo,
+  E.RewriterEnv,
   E.SectionInfo(..),
   E.riSmallBlockCount,
   E.riReusedByteCount,

--- a/renovate/src/Renovate/BinaryFormat/ELF/Rewriter.hs
+++ b/renovate/src/Renovate/BinaryFormat/ELF/Rewriter.hs
@@ -136,12 +136,14 @@ runElfRewriter :: E.ElfWidthConstraints (MM.ArchAddrWidth arch)
                => RenovateConfig arch binFmt callbacks b
                -> E.Elf (MM.ArchAddrWidth arch)
                -> ElfRewriter lm arch a
-               -> IO (a, RewriterInfo lm arch)
+               -> IO (a, RewriterInfo lm arch, Env.RewriterEnv arch)
 runElfRewriter config e a = do
   env <- Env.makeRewriterEnv config e
-  S.runStateT
-    (R.runReaderT (unElfRewrite a) env)
-    (emptyRewriterInfo e)
+  (result, info) <-
+    S.runStateT
+      (R.runReaderT (unElfRewrite a) env)
+      (emptyRewriterInfo e)
+  return (result, info, env)
 
 emptyRewriterInfo :: E.Elf (MM.ArchAddrWidth arch) -> RewriterInfo lm arch
 emptyRewriterInfo e = RewriterInfo { _riOverwrittenRegions       = []


### PR DESCRIPTION
The `riSegmentVirtualAddress` gets used downstream after rewriting for diagnostic purposes. My PR #17 took it out of the `RewriterInfo`, making it inaccessible after rewriting.