### PR TITLE
feature: remember a BasicBlock's macaw block when possible

### DIFF
--- a/renovate/src/Renovate/Address.hs
+++ b/renovate/src/Renovate/Address.hs
@@ -1,9 +1,12 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
 -- | This module defines opaque concrete and symbolic address types.
 module Renovate.Address (
+  ArchOf,
   SymbolicAddress(..),
   ConcreteAddress,
   concreteFromSegmentOff,
@@ -22,6 +25,12 @@ import qualified Numeric as N
 
 import qualified Data.Macaw.Memory as MM
 import qualified Data.Macaw.CFG as MM
+
+-- | Type family to associate types with their architecture parameter.
+type family ArchOf (x :: *) :: *
+
+type instance ArchOf (SymbolicAddress arch) = arch
+type instance ArchOf (ConcreteAddress arch) = arch
 
 
 -- | Symbolic addresses that can be referenced abstractly and

--- a/renovate/src/Renovate/BasicBlock.hs
+++ b/renovate/src/Renovate/BasicBlock.hs
@@ -1,4 +1,7 @@
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
 -- | Tools for working with 'BasicBlock's
 --
 -- This includes functions to convert between concrete and symbolic
@@ -145,7 +148,10 @@ terminatorType isa mem b =
       let (termInsn, addr) = last insns
       in isaJumpType isa termInsn mem addr
 
-prettyBasicBlock :: (PD.Pretty addr) => ISA arch -> BasicBlock addr (Instruction arch) a -> PD.Doc ann
+prettyBasicBlock ::
+  (PD.Pretty addr)
+  => ISA (ArchOf addr)
+  -> BasicBlock addr (Instruction (ArchOf addr)) a -> PD.Doc ann
 prettyBasicBlock isa b =
   PD.vsep [ PD.pretty (basicBlockAddress b) PD.<> PD.pretty ":"
           , PD.indent 2 (PD.vsep (map (PD.pretty . isaPrettyInstruction isa) (basicBlockInstructions b)))

--- a/renovate/src/Renovate/BasicBlock/Assemble.hs
+++ b/renovate/src/Renovate/BasicBlock/Assemble.hs
@@ -261,7 +261,6 @@ checkedOverlappingAssemble c overlays = do
     BlockChunk b -> withInstructionConstraints $ do
       isa <- St.gets asISA
       let blockEnd = blockEndAddress isa b
-      let reversedInstructions = reverse (basicBlockInstructions b)
       -- Assert that the overlays (i.e., blocks that overlay this current block
       -- that we are assembling) are all completely contained in the first block.
       --

--- a/renovate/src/Renovate/Redirect.hs
+++ b/renovate/src/Renovate/Redirect.hs
@@ -32,9 +32,12 @@ import qualified Data.List as L
 import           Data.Ord ( comparing )
 import qualified Data.Traversable as T
 
+
 import           Prelude
 
 import qualified Data.Macaw.CFG as MM
+import qualified Data.Macaw.CFG as MC
+
 
 import           Renovate.Address
 import           Renovate.BasicBlock
@@ -68,7 +71,10 @@ import           Renovate.Rewrite ( HasInjectedFunctions, getInjectedFunctions )
 -- The function runs in an arbitrary 'Monad' to allow instrumentors to
 -- carry around their own state.
 --
-redirect :: (MonadIO m, InstructionConstraints arch, HasInjectedFunctions m arch)
+redirect :: (MonadIO m
+            , InstructionConstraints arch
+            , HasInjectedFunctions m arch
+            , MC.ArchConstraints arch)
          => ISA arch
          -- ^ Information about the ISA in use
          -> BlockInfo arch

--- a/renovate/src/Renovate/Redirect/Symbolize.hs
+++ b/renovate/src/Renovate/Redirect/Symbolize.hs
@@ -1,6 +1,8 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE TupleSections #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
 -- | Lift concrete blocks into relocatable symbolic blocks
 module Renovate.Redirect.Symbolize (
   SymbolicAddressAllocator,
@@ -77,12 +79,16 @@ symbolizeJumps :: (InstructionConstraints arch)
                -> (ConcreteBlock arch, SymbolicAddress arch)
                -> (ConcreteBlock arch, SymbolicBlock arch)
 symbolizeJumps isa mem symAddrMap (cb, symAddr) =
-  (cb, BasicBlock { basicBlockAddress = SymbolicInfo { symbolicAddress = symAddr
-                                                     , concreteAddress = basicBlockAddress cb
-                                                     }
+  (cb, BasicBlock { basicBlockAddress =
+                    SymbolicInfo
+                    { symbolicAddress = symAddr
+                    , concreteAddress = basicBlockAddress cb
+                    }
                   , basicBlockInstructions = concat insns
+                  , basicParsedBlock = pblock
                   })
   where
+    pblock = basicParsedBlock cb
     lookupSymAddr ca = M.lookup ca symAddrMap
     insns = fmap symbolize (instructionAddresses isa cb)
 


### PR DESCRIPTION
For blocks that have corresponding Macaw blocks, keeping around the Macaw is useful as it has additional information.