### PR TITLE
Renovate.Arch: AArch64 -> AArch32

### DIFF
--- a/renovate/src/Renovate/Arch.hs
+++ b/renovate/src/Renovate/Arch.hs
@@ -12,5 +12,5 @@ data Architecture = X86_64
                   | PPC64
                   | PPC32
                   | ARM
-                  | AArch64
+                  | AArch32
                   deriving (Eq, Ord, Show)


### PR DESCRIPTION
I assume that this was intended to be AArch32 given that there is a renovate-aarch32 package but no renovate-aarch64?