### PR TITLE
Update renovate tests for new ELF findSpaceForPHDRs return value.

### DIFF
--- a/.github/workflows/ci-matrix.yml
+++ b/.github/workflows/ci-matrix.yml
@@ -52,7 +52,11 @@ jobs:
         cabal v2-configure pkg:refurbish --write-ghc-environment-files=always -j1 --enable-tests
         cabal v2-build pkg:refurbish
 
-    - name: Test
+    - name: Test renovate
+      run: |
+        cabal v2-test pkg:renovate --test-options='--use-docker-runner=False'
+
+    - name: Test refurbish
       if: runner.os == 'Linux'
       # NOTE: Locally, we use a docker runner to isolate test cases in case the
       # rewriter breaks them in a dangerous way. Docker-in-docker isn't so great

--- a/.github/workflows/ci-matrix.yml
+++ b/.github/workflows/ci-matrix.yml
@@ -46,7 +46,19 @@ jobs:
         restore-keys: |
           cabal-${{ runner.os }}-${{ matrix.ghc }}-${{ hashFiles(format('cabal.GHC-{0}.config', matrix.ghc)) }}-
 
-    - name: Build
+    - name: Build renovate
+      run: |
+        cp cabal.project.dist cabal.project
+        cabal v2-configure pkg:renovate --write-ghc-environment-files=always -j1 --enable-tests
+        cabal v2-build pkg:renovate
+
+    - name: Build renovate x86
+      run: |
+        cp cabal.project.dist cabal.project
+        cabal v2-configure pkg:renovate-x86 --write-ghc-environment-files=always -j1 --enable-tests
+        cabal v2-build pkg:renovate-x86
+
+    - name: Build refurbish
       run: |
         cp cabal.project.dist cabal.project
         cabal v2-configure pkg:refurbish --write-ghc-environment-files=always -j1 --enable-tests
@@ -54,7 +66,11 @@ jobs:
 
     - name: Test renovate
       run: |
-        cabal v2-test pkg:renovate --test-options='--use-docker-runner=False'
+        cabal v2-test pkg:renovate
+
+    - name: Test renovate x86
+      run: |
+        cabal v2-test pkg:renovate-x86
 
     - name: Test refurbish
       if: runner.os == 'Linux'

--- a/renovate-x86/renovate-x86.cabal
+++ b/renovate-x86/renovate-x86.cabal
@@ -61,8 +61,10 @@ test-suite renovate-x86-tests
                  elf-edit,
                  filepath,
                  tasty-hunit,
+                 lumberjack,
                  macaw-loader,
                  macaw-loader-x86,
+                 prettyprinter,
                  renovate,
                  renovate-x86,
                  crucible

--- a/renovate-x86/renovate-x86.cabal
+++ b/renovate-x86/renovate-x86.cabal
@@ -34,7 +34,7 @@ library
                        parameterized-utils,
                        ansi-wl-pprint,
                        exceptions,
-                       prettyprinter,
+                       prettyprinter >= 1.7.0,
                        located-base >= 0.1 && < 0.2,
                        renovate
   hs-source-dirs:      src

--- a/renovate/src/Renovate/BinaryFormat/ELF.hs
+++ b/renovate/src/Renovate/BinaryFormat/ELF.hs
@@ -628,7 +628,6 @@ choosePHDRSegmentAddress elf = do
   -- one can't be found.
   (tlssegment, segmentInfos) <- indexLoadableSegments elf fakePhdrSeg
   case findSpaceForPHDRs segmentInfos projectedOffset requiredSize of
-    NoAddress -> P.throwM $ NoSpaceForPHDRs (fromIntegral projectedOffset) (fromIntegral requiredSize)
     TLSSafeAddress addr -> pure addr
     FallbackAddress addr ->
       -- The fallback address is a free address that does not obey all of the

--- a/renovate/src/Renovate/BinaryFormat/ELF/Internal.hs
+++ b/renovate/src/Renovate/BinaryFormat/ELF/Internal.hs
@@ -51,9 +51,8 @@ makeLoadSegmentInfo phdr =
                               , pMemSz = E.phdrMemSize phdr
                               }
 
-data PHDRAddress w = TLSSafeAddress (E.ElfWordType w)
+data PHDRAddress w = TLSSafeAddress (E.ElfWordType w)  -- TLS = Thread Local Storage
                    | FallbackAddress (E.ElfWordType w)
-                   | NoAddress
 
 deriving instance Eq (E.ElfWordType w) => Eq (PHDRAddress w)
 deriving instance Show (E.ElfWordType w) => Show (PHDRAddress w)

--- a/renovate/src/Renovate/BinaryFormat/ELF/Internal.hs
+++ b/renovate/src/Renovate/BinaryFormat/ELF/Internal.hs
@@ -55,6 +55,10 @@ data PHDRAddress w = TLSSafeAddress (E.ElfWordType w)
                    | FallbackAddress (E.ElfWordType w)
                    | NoAddress
 
+deriving instance Eq (E.ElfWordType w) => Eq (PHDRAddress w)
+deriving instance Show (E.ElfWordType w) => Show (PHDRAddress w)
+-- Eq and Show instances are primarily for unit testing
+
 -- | Find a spot in the program's virtual address space for the new PHDR segment
 --
 -- This is an implementation of the core of 'choosePHDRSegmentAddress', see the

--- a/renovate/src/Renovate/BinaryFormat/ELF/Internal.hs
+++ b/renovate/src/Renovate/BinaryFormat/ELF/Internal.hs
@@ -104,12 +104,14 @@ findSpaceForPHDRs segInfos phdrOffset phdrSize =
       --
       -- In detail: For every pair (loSeg, hiSeg) of segments that are adjacent
       -- in the virtual address space,
-      -- * Find the lowest aligned address after the end of loSeg. If this
-      --   address plus the size of the PHDRs is less than the address of hiSeg,
-      --   add it to the set of candidate addresses.
-      -- * Find the highest aligned address before the start of hiSeg minus the
-      --   size of the PHDRs. If this address is higher than the end of loSeg,
-      --   add it to the set of candidate addresses.
+      --
+      --  * Find the lowest aligned address after the end of loSeg. If this
+      --    address plus the size of the PHDRs is less than the address of hiSeg,
+      --    add it to the set of candidate addresses.
+      --
+      --  * Find the highest aligned address before the start of hiSeg minus the
+      --    size of the PHDRs. If this address is higher than the end of loSeg,
+      --    add it to the set of candidate addresses.
       --
       -- In a later step, we winnow down these candidates to find the optimal
       -- address.

--- a/renovate/tests/Main.hs
+++ b/renovate/tests/Main.hs
@@ -50,7 +50,7 @@ findSpaceForPHDRsTests :: T.TestTree
 findSpaceForPHDRsTests =
   T.testGroup "findSpaceForPHDRsTests" $
     [ T.testCase "Can't get closer than optimal" $
-        Nothing T.@=?
+        ELF.FallbackAddress 0x201000 T.@=?
           let info :: ELF.LoadSegmentInfo 64
               info = ELF.LoadSegmentInfo
                        { ELF.pOffset = someELFWord
@@ -59,7 +59,7 @@ findSpaceForPHDRsTests =
                        }
           in ELF.findSpaceForPHDRs (info NEL.:| []) someELFWord someELFWord
     , T.testCase "Before all other segments" $
-        Just 0x1ff000 T.@=?
+        ELF.TLSSafeAddress 0x1ff000 T.@=?
           let info1 :: ELF.LoadSegmentInfo 64
               info1 = ELF.LoadSegmentInfo
                         { ELF.pOffset = someELFWord
@@ -80,7 +80,7 @@ findSpaceForPHDRsTests =
         -- LOAD           0x066b7c 0x00086b7c 0x00086b7c 0x01364 0x02374 RW  0x10000
         let offset = 0xA3000
         in
-          Just offset T.@=?
+          ELF.TLSSafeAddress offset T.@=?
             let info1 :: ELF.LoadSegmentInfo 64
                 info1 = ELF.LoadSegmentInfo
                           { ELF.pOffset = 0x0
@@ -102,7 +102,7 @@ findSpaceForPHDRsTests =
         -- Type           Offset   VirtAddr   PhysAddr   FileSiz MemSiz   Flg Align
         -- LOAD           0x000000 0x00010000 0x00010000 0x0031c 0x0031c  R E 0x10000
         -- LOAD           0x00031c 0x0002031c 0x0002031c 0x00004 0x400008 RW  0x10000
-        Nothing T.@=?
+        ELF.NoAddress T.@=?
           let info1 :: ELF.LoadSegmentInfo 64
               info1 = ELF.LoadSegmentInfo
                         { ELF.pOffset = 0x0
@@ -119,7 +119,7 @@ findSpaceForPHDRsTests =
     , T.testCase "test-just-exit.nostdlib.ppc64.exe" $
         -- LOAD 0x000000000 0x010000000 0x010000000 0x0000b2a11 0x0000b2a11  R E    0x10000
         -- LOAD 0x0000b9c80 0x0100c9c80 0x0100c9c80 0x000008448 0x000009aa8  RW     0x10000
-        Just 0xffff000 T.@=?
+        ELF.TLSSafeAddress 0xffff000 T.@=?
           let info1 :: ELF.LoadSegmentInfo 64
               info1 = ELF.LoadSegmentInfo
                         { ELF.pOffset = 0x0

--- a/renovate/tests/Main.hs
+++ b/renovate/tests/Main.hs
@@ -95,14 +95,16 @@ findSpaceForPHDRsTests =
                           }
             in ELF.findSpaceForPHDRs (info1 NEL.:| [info2]) offset 0x160
     -- Values in the following test case are taken from
-    -- linked-list.noopt.nostdlib.aarch32.exe. Unfortunately, it is
-    -- unsatisfiable because the .bss section has a HUGE buffer in it, which
-    -- overlaps with where we want to put the new PHDRs.
+    -- linked-list.noopt.nostdlib.aarch32.exe. The .bss section has a
+    -- HUGE buffer in it, which overlaps with the optimal placement of
+    -- a new PHDR segment.  However, we can still find a
+    -- FallbackAddress which is safe assuming the binary has no TLS
+    -- (Thread Local Storage) segment (and it doesn't).
     , T.testCase "linked-list.noopt.nostdlib.aarch32.exe" $
         -- Type           Offset   VirtAddr   PhysAddr   FileSiz MemSiz   Flg Align
         -- LOAD           0x000000 0x00010000 0x00010000 0x0031c 0x0031c  R E 0x10000
         -- LOAD           0x00031c 0x0002031c 0x0002031c 0x00004 0x400008 RW  0x10000
-        ELF.NoAddress T.@=?
+        ELF.FallbackAddress 0x421000 T.@=?
           let info1 :: ELF.LoadSegmentInfo 64
               info1 = ELF.LoadSegmentInfo
                         { ELF.pOffset = 0x0


### PR DESCRIPTION
Updates tests for new findSpaceForPHDRs return value.

oAt present, the tests do *not* pass: the tests are modified to indicate what I believe the intended results are, but the renovate code at present does not satisfy one of the tests.  I believe this indicates an issue in the core findSpaceForPHDRs change: it's not clear that the NoAddress return value would ever be generated.