### PR TITLE
Update refurbish flag to --no-docker-runner

### DIFF
--- a/.github/workflows/ci-matrix.yml
+++ b/.github/workflows/ci-matrix.yml
@@ -80,5 +80,5 @@ jobs:
       run: |
         sudo apt update
         sudo apt install qemu-user-binfmt qemu-user
-        cabal v2-test pkg:refurbish --test-options='--use-docker-runner=False'
+        cabal v2-test pkg:refurbish --test-options='--no-docker-runner=True'
 

--- a/refurbish/tests/Main.hs
+++ b/refurbish/tests/Main.hs
@@ -56,10 +56,11 @@ data UseDockerRunner = UseDockerRunner Bool
   deriving (Eq, Ord, Show)
 
 instance TO.IsOption UseDockerRunner where
-  defaultValue = UseDockerRunner True
+  defaultValue = UseDockerRunner False
   parseValue = fmap UseDockerRunner . TO.safeReadBool
   optionName = pure "use-docker-runner"
   optionHelp = pure "Use the docker runner for each test binary"
+  optionCLParser = TO.flagCLParser Nothing (UseDockerRunner True)
 
 main :: IO ()
 main = do

--- a/refurbish/tests/Main.hs
+++ b/refurbish/tests/Main.hs
@@ -56,11 +56,11 @@ data UseDockerRunner = UseDockerRunner Bool
   deriving (Eq, Ord, Show)
 
 instance TO.IsOption UseDockerRunner where
-  defaultValue = UseDockerRunner False
+  defaultValue = UseDockerRunner True
   parseValue = fmap UseDockerRunner . TO.safeReadBool
-  optionName = pure "use-docker-runner"
-  optionHelp = pure "Use the docker runner for each test binary"
-  optionCLParser = TO.flagCLParser Nothing (UseDockerRunner True)
+  optionName = pure "no-docker-runner"
+  optionHelp = pure "Do not the docker runner for each test binary"
+  optionCLParser = TO.flagCLParser Nothing (UseDockerRunner False)
 
 main :: IO ()
 main = do


### PR DESCRIPTION
This changes the default to be "yes, use docker" which is much safer for random developers running a `cabal test` (which is what the docker use is intended for).

Also simplifies the option parsing.
