### PR TITLE
refurbish test updates

### DIFF
--- a/refurbish/refurbish.cabal
+++ b/refurbish/refurbish.cabal
@@ -17,6 +17,7 @@ cabal-version:       >=1.10
 
 library
   exposed-modules:     Refurbish.Docker
+                       Refurbish.QEMU
                        Refurbish.Tutorial
   build-depends: base,
                  crucible,

--- a/refurbish/refurbish.cabal
+++ b/refurbish/refurbish.cabal
@@ -111,6 +111,7 @@ test-suite refurbish-tests
                  lumberjack,
                  prettyprinter,
                  tasty,
+                 tasty-checklist >= 1.0 && < 1.1,
                  tasty-hunit,
                  text,
                  filemanip,

--- a/refurbish/src/Refurbish/QEMU.hs
+++ b/refurbish/src/Refurbish/QEMU.hs
@@ -1,0 +1,36 @@
+{-# LANGUAGE GADTs #-}
+
+-- | Utilities for working with user-space QEMU.
+
+module Refurbish.QEMU
+  (
+    qemulator
+  )
+where
+
+import qualified Data.ByteString as BS
+import qualified Data.ElfEdit as Elf
+import           Data.Maybe ( fromMaybe )
+
+
+-- | Determines the proper QEMU user-space emulator to run for the
+-- specified executable file.
+
+qemulator :: FilePath -> IO String
+qemulator exe =
+  do bytes <- BS.readFile exe
+     case Elf.decodeElfHeaderInfo bytes of
+       Left (byteOff, msg) -> do
+         error ("Error decoding target execution ELF file"
+                <> " at " <> show byteOff <> ": " <> msg)
+       Right (Elf.SomeElf e0) ->
+         let hdr = Elf.header e0
+             qemus = [ (Elf.EM_PPC,    "qemu-ppc")
+                     , (Elf.EM_PPC64,  "qemu-ppc64")
+                     , (Elf.EM_X86_64, "qemu-x86_64")
+                     , (Elf.EM_ARM,    "qemu-arm")
+                     ]
+             no_qemu = error ("Unsupported target execution ELF type: "
+                              <> show (Elf.headerMachine hdr) <> " "
+                              <> show (Elf.headerClass hdr))
+         in return $ fromMaybe no_qemu $ lookup (Elf.headerMachine hdr) qemus

--- a/refurbish/tests/Identity.hs
+++ b/refurbish/tests/Identity.hs
@@ -17,8 +17,8 @@ analysis =
                       , R.arRewrite = R.identity
                       }
 
-allOutputEqual :: (E.ExitCode, E.ExitCode) -> (String, String) -> (String, String) -> IO ()
-allOutputEqual (origRC, modRC) (origOut, modOut) (origErr, modErr) = do
+allOutputEqual :: (E.ExitCode, String, String) -> (E.ExitCode, String, String) -> IO ()
+allOutputEqual (origRC, origOut, origErr) (modRC, modOut, modErr) = do
   T.assertEqual "Stdout" origOut modOut
   T.assertEqual "Stderr" origErr modErr
   T.assertEqual "Exit code" origRC modRC

--- a/refurbish/tests/Inject.hs
+++ b/refurbish/tests/Inject.hs
@@ -79,8 +79,8 @@ ppc64Inject env _ (InjectedAddr addr) sb = do
 -- | Instead of making sure the original and rewritten have the same behavior,
 -- we want to make sure that the original binary fails and the new binary exits
 -- with 0.
-injectionEquality :: (E.ExitCode, E.ExitCode) -> (String, String) -> (String, String) -> IO ()
-injectionEquality (origRC, modRC) _ _ = do
+injectionEquality :: (E.ExitCode, String, String) -> (E.ExitCode, String, String) -> IO ()
+injectionEquality (origRC, _, _) (modRC, _, _) = do
   case origRC of
     E.ExitSuccess -> T.assertFailure "Base binary succeeded"
     E.ExitFailure _ -> T.assertEqual "Expected the rewritten binary to succeed" E.ExitSuccess modRC

--- a/refurbish/tests/Inject.hs
+++ b/refurbish/tests/Inject.hs
@@ -1,9 +1,13 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+
 module Inject (
   injectionAnalysis,
   ppc64Inject,
@@ -15,9 +19,10 @@ import qualified Data.Foldable as F
 import           Data.Functor.Const ( Const(..) )
 import qualified Data.List.NonEmpty as DLN
 import           Data.Parameterized.Classes
+import           Data.Parameterized.Context ( pattern Empty, pattern (:>) )
 import           Data.Parameterized.Some ( Some(..) )
 import qualified System.Exit as E
-import qualified Test.Tasty.HUnit as T
+import           Test.Tasty.Checklist
 
 import qualified Data.Macaw.BinaryLoader as MBL
 import           Data.Macaw.BinaryLoader.X86 ()
@@ -80,7 +85,17 @@ ppc64Inject env _ (InjectedAddr addr) sb = do
 -- we want to make sure that the original binary fails and the new binary exits
 -- with 0.
 injectionEquality :: (E.ExitCode, String, String) -> (E.ExitCode, String, String) -> IO ()
-injectionEquality (origRC, _, _) (modRC, _, _) = do
-  case origRC of
-    E.ExitSuccess -> T.assertFailure "Base binary succeeded"
-    E.ExitFailure _ -> T.assertEqual "Expected the rewritten binary to succeed" E.ExitSuccess modRC
+injectionEquality origRes modRes =
+  let origRC ((v, _, _), _) = v
+      modRC (_, (v, _, _)) = v
+      modErr (_, (_, _, s)) = s
+  in withChecklist "injection execution results" $
+     (origRes, modRes) `checkValues`
+     (Empty
+      :> Val "original binary fails"      ((E.ExitSuccess ==) . origRC) False
+      :> Val "rewritten binary succeeds"  modRC  E.ExitSuccess
+      :> Val "rewritten binary no errors" modErr ""
+     )
+
+
+instance TestShow E.ExitCode where testShow = show

--- a/refurbish/tests/Main.hs
+++ b/refurbish/tests/Main.hs
@@ -209,7 +209,7 @@ testRewriter :: ( w ~ MM.ArchAddrWidth arch
              -> C.HandleAllocator
              -> R.LayoutStrategy
              -> FilePath
-             -> ((E.ExitCode, E.ExitCode) -> (String, String) -> (String, String) -> IO ())
+             -> ((E.ExitCode, String, String) -> (E.ExitCode, String, String) -> IO ())
              -> R.RenovateConfig arch (E.ElfHeaderInfo w) (R.AnalyzeAndRewrite lm) (Const ())
              -> E.ElfHeaderInfo w
              -> MBL.LoadedBinary arch (E.ElfHeaderInfo w)
@@ -237,10 +237,10 @@ testRewriter (UseDockerRunner useDocker) verbose mRunner hdlAlloc strat exePath 
         argLists <- readTestArguments exePath
         F.forM_ argLists $ \argList -> do
           let origTarget = pwd </> exePath
-          (origRC, origOut, origErr) <- executor runner [(origTarget, origTarget)] (origTarget : argList)
+          origres <- executor runner [(origTarget, origTarget)] (origTarget : argList)
           let newTarget = texe
-          (modRC, modOut, modErr) <- executor runner [(newTarget, newTarget)] (newTarget : argList)
-          assertions (origRC, modRC) (origOut, modOut) (origErr, modErr)
+          modres <- executor runner [(newTarget, newTarget)] (newTarget : argList)
+          assertions origres modres
   where
     executor | useDocker = RD.runInContainer
              | otherwise = runWithoutContainer


### PR DESCRIPTION
Various updates  to refurbish, including
* Making QEMU user-space emulation use explicit (rather than the implicit dependency on binfmt_misc).  This applies to both tests and normal use of refurbish tooling.
* Ensure all test executables are actually executable for testing.
* The bind-mount process for Docker has assumptions/dependencies between the Docker and local filesystems.  Specifically, a target directory on the host that doesn't exist in Docker (e.g. different distros) seems to fail without failing (no docker error, but the bind mount target isn't present).  This changes to use a known good location for the in-Docker target and seems to have eliminated these issues.