### PR TITLE
Add Docker logging; no Docker create if not used for tests.

### DIFF
--- a/refurbish/refurbish.cabal
+++ b/refurbish/refurbish.cabal
@@ -28,6 +28,7 @@ library
                  temporary,
                  tasty,
                  tasty-hunit,
+                 text,
                  filemanip,
                  filepath,
                  lumberjack,
@@ -90,7 +91,9 @@ executable refurbish-run
   build-depends:       base >=4.10 && <5,
                        directory,
                        filepath,
-                       refurbish
+                       lumberjack,
+                       refurbish,
+                       text
   hs-source-dirs:      tools/refurbish-run
   default-language:    Haskell2010
   ghc-options: -Wall -rtsopts -threaded


### PR DESCRIPTION
* Adds lumberjack-based logging to the docker run
* Updates to the refurbish tests to avoid initializing docker if not requested and capture common execution functionality.