### PR TITLE
Use CI_TEST_LEVEL to control refurbish test selection.

### DIFF
--- a/.github/workflows/ci-matrix.yml
+++ b/.github/workflows/ci-matrix.yml
@@ -24,6 +24,9 @@ jobs:
 
     name: GHC ${{ matrix.ghc }} on ${{ matrix.os }} renovate
 
+    env:
+      CI_TEST_LEVEL: "2"
+
     steps:
     - uses: actions/checkout@v2
       with:


### PR DESCRIPTION
Normal tests without this env var set just run a sample subset and generally complete in less than 1 minute.

When set to level 1, a more extensive group of tests is selected, and runtime is approximately 12 minutes.

When set to level 2 (used for github actions CI), all tests are selected, runtime is very long.
