### PR TITLE
Make section treated as ".text" configurable

### DIFF
--- a/renovate-ppc/src/Renovate/Arch/PPC.hs
+++ b/renovate-ppc/src/Renovate/Arch/PPC.hs
@@ -63,6 +63,7 @@ config32 analysis = R.RenovateConfig
   , R.rcDataLayoutBase = 0x20000000
   , R.rcExtratextOffset = 0
   , R.rcRefinementConfig = Nothing
+  , R.rcTextSectionName = ".text"
   }
 
 -- | A renovate configuration for 64 bit PowerPC
@@ -89,6 +90,7 @@ config64 analysis = R.RenovateConfig
   , R.rcDataLayoutBase = 0x20000000
   , R.rcExtratextOffset = 0
   , R.rcRefinementConfig = Nothing
+  , R.rcTextSectionName = ".text"
   }
 
 {- Note [Layout Addresses]

--- a/renovate-x86/src/Renovate/Arch/X86_64.hs
+++ b/renovate-x86/src/Renovate/Arch/X86_64.hs
@@ -73,6 +73,7 @@ config analysis = R.RenovateConfig
   , R.rcDataLayoutBase = 0xa00000
   , R.rcExtratextOffset = 0
   , R.rcRefinementConfig = Nothing
+  , R.rcTextSectionName = ".text"
   }
 
 {- Note [Layout Addresses]

--- a/renovate/src/Renovate/BinaryFormat/ELF/Common.hs
+++ b/renovate/src/Renovate/BinaryFormat/ELF/Common.hs
@@ -54,15 +54,15 @@ allocatedVAddrsM e = case allocatedVAddrs e of
   Left seg -> C.throwM (RCE.SegmentHasRelativeSize (toInteger (E.elfSegmentIndex seg)))
   Right m -> return m
 
-findTextSections :: E.Elf w -> [E.ElfSection (E.ElfWordType w)]
-findTextSections = E.findSectionByName (C8.pack ".text")
+findTextSections :: String -> E.Elf w -> [E.ElfSection (E.ElfWordType w)]
+findTextSections secName = E.findSectionByName (C8.pack secName)
 
-findTextSection :: C.MonadThrow m => E.Elf w -> m (E.ElfSection (E.ElfWordType w))
-findTextSection e = do
-  case findTextSections e of
+findTextSection :: C.MonadThrow m => String -> E.Elf w -> m (E.ElfSection (E.ElfWordType w))
+findTextSection secName e = do
+  case findTextSections secName e of
     [textSection] -> return textSection
-    [] -> C.throwM (RCE.MissingExpectedSection ".text")
-    sections -> C.throwM (RCE.MultipleSectionDefinitions ".text" (length sections))
+    [] -> C.throwM (RCE.MissingExpectedSection secName)
+    sections -> C.throwM (RCE.MultipleSectionDefinitions secName (length sections))
 
 -- | The system page alignment (assuming 4k pages)
 pageAlignment :: Word64

--- a/renovate/src/Renovate/Config.hs
+++ b/renovate/src/Renovate/Config.hs
@@ -211,6 +211,9 @@ data RenovateConfig arch binFmt callbacks (b :: Type -> Type) = RenovateConfig
   , rcRefinementConfig :: Maybe MR.RefinementConfig
   -- ^ Optional configuration for macaw-refinement; if provided, call
   -- macaw-refinement to find additional code through SMT-based refinement
+  , rcTextSectionName :: String
+  -- ^ The name of the text section including the leading dot, e.g.
+  -- ".text"
   }
 
 -- | Compose a list of instrumentation functions into a single


### PR DESCRIPTION
While ".text" is commonly the name given to the Elf section containing program code, it turns out that this isn't always the case. I encountered a binary for PowerPC intended for the "Book E" extended PowerPC architecture that had an empty ".text" section and instead provided all of its program code in a section called ".text_booke". That meant that renovate failed to find code in the binary since the assumption that ".text" would be the right section name was hard-coded in a couple of places. This change generalizes how the text section is identified by making it configurable in RenovateConfig to allow for this situation while still defaulting to ".text" to support the most common cases.

This change:

* Adds a RenovateConfig field, rcTextSectionName, to track which section Renovate should treat as the ".text" section of the binary that it is processing.

* Updates RewriterEnv to carry the text section name as specified in the RenovateConfig so that the section name can be available in the ElfRewriter monad.

* Updates makeRewriterEnv to use the new setting when it calls findTextSection.

* Updates the X86_64 and PPC implementations to use ".text" in their default RenovateConfigs.